### PR TITLE
fix: handle resourceUri in Open with File for explorer context menu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 
 - `src/extension.ts` — Thin activation/wiring layer for commands, status bar, terminal profile, chat participant, and bridge lifecycle
 - `src/pi.ts` — Pi binary resolution, install prompt, launch args, bridge env helpers
-- `src/terminal.ts` — Terminal creation, terminal placement, open-with-file context helpers
+- `src/terminal.ts` — Terminal creation (with optional cwd override), terminal placement, open-with-file context helpers (supports explorer resourceUri + multi-root workspace folder resolution)
 - `src/chat.ts` — RPC-backed `@pi` chat handler with terminal fallback
 - `src/sessions.ts` — Per-terminal pi session tracking and restore-on-activation helper (workspaceState-backed)
 - `src/bridge/server.ts` — HTTP server setup, auth, request parsing, VS Code event subscriptions

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const openTerminal = async (
     extraArgs?: string[],
     contextLines?: string[],
+    cwd?: string,
   ): Promise<vscode.Terminal | undefined> => {
     const terminalId = randomUUID();
     const terminal = await createNewTerminal({
@@ -41,6 +42,7 @@ export async function activate(context: vscode.ExtensionContext) {
       extraArgs,
       contextLines,
       terminalId,
+      cwd,
     });
     if (terminal) sessions.track(terminal, terminalId);
     return terminal;
@@ -73,8 +75,9 @@ export async function activate(context: vscode.ExtensionContext) {
       const terminal = await openTerminal();
       terminal?.show();
     }),
-    vscode.commands.registerCommand("pi-vscode.openWithFile", async () => {
-      const terminal = await openTerminal(undefined, buildOpenWithFileContext());
+    vscode.commands.registerCommand("pi-vscode.openWithFile", async (resourceUri?: vscode.Uri) => {
+      const { contextLines, cwd } = buildOpenWithFileContext(resourceUri);
+      const terminal = await openTerminal(undefined, contextLines, cwd);
       terminal?.show();
     }),
     vscode.commands.registerCommand("pi-vscode.sendSelection", async () => {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -9,11 +9,12 @@ export async function createNewTerminal(options: {
   contextLines?: string[];
   terminalId?: string;
   sessionFile?: string;
+  cwd?: string;
 }): Promise<vscode.Terminal | undefined> {
   const piPath = await ensurePiBinary();
   if (!piPath) return undefined;
 
-  const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  const cwd = options.cwd ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
   const viewColumn = findPiColumn() ?? findUnusedColumn() ?? vscode.ViewColumn.Beside;
   const extraArgs = options.sessionFile
     ? ["--session", options.sessionFile, ...(options.extraArgs ?? [])]
@@ -46,13 +47,28 @@ export async function createNewTerminal(options: {
   return terminal;
 }
 
-export function buildOpenWithFileContext(): string[] {
+export function buildOpenWithFileContext(resourceUri?: vscode.Uri): {
+  contextLines: string[];
+  cwd?: string;
+} {
   const lines: string[] = [];
-  const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-  if (workspaceRoot) lines.push(`The workspace root is: ${workspaceRoot}`);
-
   const editor = vscode.window.activeTextEditor;
-  if (!editor) return lines;
+
+  // Prefer the explicit resource URI (from explorer context menu), fall back to active editor
+  const fileUri = resourceUri ?? editor?.document.uri;
+  const workspaceFolder = fileUri
+    ? vscode.workspace.getWorkspaceFolder(fileUri)
+    : vscode.workspace.workspaceFolders?.[0];
+  const cwd = workspaceFolder?.uri.fsPath;
+  if (cwd) lines.push(`The workspace root is: ${cwd}`);
+
+  // When invoked from explorer context menu with a resource URI, use that file path
+  if (resourceUri) {
+    lines.push(`The user is currently viewing this file in their editor: ${resourceUri.fsPath}`);
+    return { contextLines: lines, cwd };
+  }
+
+  if (!editor) return { contextLines: lines, cwd };
 
   const fileName = editor.document.fileName;
   const selection = editor.selection;
@@ -61,14 +77,14 @@ export function buildOpenWithFileContext(): string[] {
     lines.push(
       `The cursor is at line ${selection.active.line + 1}, character ${selection.active.character + 1}.`,
     );
-    return lines;
+    return { contextLines: lines, cwd };
   }
 
   lines.push(`The user is currently viewing this file in their editor: ${fileName}`);
   lines.push(
     `The current selection spans lines ${selection.start.line + 1}-${selection.end.line + 1}. Use the VS Code bridge to inspect the exact selected text if needed.`,
   );
-  return lines;
+  return { contextLines: lines, cwd };
 }
 
 function findPiColumn(): vscode.ViewColumn | undefined {


### PR DESCRIPTION
When 'Pi: Open with File' is invoked from the explorer context menu, VS Code passes the selected file's URI as an argument. Previously this was ignored, so the command always fell back to the active editor and used the first workspace folder as cwd.

Changes:
- Accept resourceUri parameter in the openWithFile command handler
- buildOpenWithFileContext() prefers the explicit resourceUri over the active editor, and resolves the correct workspace folder for the file
- Return cwd alongside contextLines so the terminal starts in the matching workspace folder (important for multi-root workspaces)
- createNewTerminal() accepts an optional cwd override