### PR TITLE
Support active workspace folder for Pi terminals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ See [.agents/docs/icons.md](.agents/docs/icons.md)
 - In multi-root windows, Pi terminals, terminal profiles, open-with-file context, and `@pi` chat RPC use the workspace folder containing the active editor, falling back to the first folder only when no active editor folder is available
 - Terminal cleaned up on close, recreated on next command
 - CJS wrapper pattern allows `"type": "module"` while satisfying VS Code's `require()` loading
-- Pi binary auto-detected from common paths (`~/.bun/bin/pi`, `~/.local/bin/pi`, etc.) or configurable via `pi-vscode.path` setting
+- Pi binary auto-detected from common paths (`~/.bun/bin/pi`, `~/.local/bin/pi`, etc.) or configurable via the `pi-vscode.path` setting, which supports VS Code-style variables (`${userHome}`, `${workspaceFolder}`, `${workspaceFolder:name}`, `${env:NAME}`, `${/}`)
 - `Pi: Upgrade Pi and Packages` reuses the binary resolver, guesses the package manager from the discovered binary path, launches the corresponding global install command for `@mariozechner/pi-coding-agent@latest`, and chains `pi update` afterward
 - Terminal shell is the pi binary itself (not a shell running pi)
 - Every pi launch injects `PI_VSCODE_BRIDGE_URL`, `PI_VSCODE_BRIDGE_TOKEN`, and a per-terminal `PI_VSCODE_TERMINAL_ID` plus `--extension bridge/pi-vscode-bridge.js`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
 - `src/extension.ts` — Thin activation/wiring layer for commands, status bar, terminal profile, chat participant, and bridge lifecycle
 - `src/pi.ts` — Pi binary resolution, install prompt, launch args, bridge env helpers
 - `src/terminal.ts` — Terminal creation, terminal placement, open-with-file context helpers
+- `src/workspace.ts` — Active-editor workspace folder resolution shared by terminal launch and chat RPC cwd selection
 - `src/chat.ts` — RPC-backed `@pi` chat handler with terminal fallback
 - `src/sessions.ts` — Per-terminal pi session tracking and restore-on-activation helper (workspaceState-backed)
 - `src/bridge/server.ts` — HTTP server setup, auth, request parsing, VS Code event subscriptions
@@ -64,6 +65,7 @@ See [.agents/docs/icons.md](.agents/docs/icons.md)
 ## Notes
 
 - One pi terminal profile per window; new launches reuse the same title and colocate beside the editor
+- In multi-root windows, Pi terminals, terminal profiles, open-with-file context, and `@pi` chat RPC use the workspace folder containing the active editor, falling back to the first folder only when no active editor folder is available
 - Terminal cleaned up on close, recreated on next command
 - CJS wrapper pattern allows `"type": "module"` while satisfying VS Code's `require()` loading
 - Pi binary auto-detected from common paths (`~/.bun/bin/pi`, `~/.local/bin/pi`, etc.) or configurable via `pi-vscode.path` setting

--- a/README.md
+++ b/README.md
@@ -106,8 +106,9 @@ These bridge tools let pi inspect selections, diagnostics, symbols, definitions,
 
 ## Configuration
 
-| Setting          | Default | Description                                             |
-| ---------------- | ------- | ------------------------------------------------------- |
-| `pi-vscode.path` | `""`    | Absolute path to the pi binary (auto-detected if empty) |
+| Setting          | Default | Description                                                                                                                                                                              |
+| ---------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pi-vscode.path` | `""`    | Absolute path to the pi binary; supports VS Code-style variables like `${userHome}`, `${workspaceFolder}`, `${workspaceFolder:name}`, `${env:NAME}`, and `${/}` (auto-detected if empty) |
 
 On Windows, an extensionless `pi-vscode.path` is auto-probed for `.cmd`/`.exe`/`.ps1` variants so extensionless npm shims work out of the box.
+For example: `${userHome}/.bun/bin/pi` or `${workspaceFolder:Client}${/}node_modules${/}.bin${/}pi`.

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
         "pi-vscode.path": {
           "type": "string",
           "default": "",
-          "description": "Absolute path to the pi binary. Leave empty for auto-detection."
+          "description": "Absolute path to the pi binary. Supports VS Code-style variables such as ${userHome}, ${workspaceFolder}, ${workspaceFolder:name}, ${env:NAME}, and ${/}. Leave empty for auto-detection."
         }
       }
     },

--- a/src/_resolve.ts
+++ b/src/_resolve.ts
@@ -18,13 +18,15 @@ export interface ResolveOptions {
   localAppData?: string;
   /** Workspace root directories */
   workspaceDirs?: string[];
+  /** Environment variables used for custom path expansion (defaults to process.env) */
+  env?: Record<string, string | undefined>;
   /** File access check (defaults to fs.accessSync) */
   access?: (path: string, mode: number) => void;
 }
 
 export function resolvePiBinary(opts: ResolveOptions = {}): string {
   const platform = opts.platform ?? process.platform;
-  const home = opts.home ?? process.env.HOME ?? process.env.USERPROFILE ?? "";
+  const home = opts.home ?? defaultHome(platform);
   const pathEnv = opts.pathEnv ?? process.env.PATH ?? "";
   const workspaceDirs = opts.workspaceDirs ?? [];
   const access = opts.access ?? accessSync;
@@ -38,11 +40,17 @@ export function resolvePiBinary(opts: ResolveOptions = {}): string {
   // Extensionless npm shims on Windows are bash scripts that cannot be spawned;
   // probe for .cmd/.exe/.ps1 variants when the custom path has no extension.
   if (opts.customPath) {
+    const customPath = expandPathVariables(opts.customPath, {
+      env: opts.env ?? process.env,
+      home,
+      platform,
+      workspaceDirs,
+    });
     if (isWin) {
-      const resolved = resolveWindowsExecutable(opts.customPath, access);
+      const resolved = resolveWindowsExecutable(customPath, access);
       if (resolved) return resolved;
     }
-    return opts.customPath;
+    return customPath;
   }
 
   // Check workspace-local node_modules/.bin first (respects monorepos / multi-root)
@@ -77,6 +85,67 @@ export function resolvePiBinary(opts: ResolveOptions = {}): string {
   }
 
   return "pi";
+}
+
+type PathVariableContext = {
+  env: Record<string, string | undefined>;
+  home: string;
+  platform: string;
+  workspaceDirs: string[];
+};
+
+function defaultHome(platform: string): string {
+  return platform === "win32"
+    ? (process.env.USERPROFILE ?? process.env.HOME ?? "")
+    : (process.env.HOME ?? process.env.USERPROFILE ?? "");
+}
+
+function expandPathVariables(value: string, context: PathVariableContext): string {
+  return value.replace(/\$\{([^}]+)\}/g, (match, variable: string) => {
+    switch (variable) {
+      case "userHome":
+        return context.home;
+      case "workspaceFolder":
+        return context.workspaceDirs[0] ?? match;
+      case "workspaceFolderBasename":
+        return context.workspaceDirs[0] ? pathBasename(context.workspaceDirs[0]) : match;
+      case "pathSeparator":
+      case "/":
+        return context.platform === "win32" ? "\\" : "/";
+      default:
+        break;
+    }
+
+    if (variable.startsWith("env:")) {
+      return readEnv(context.env, variable.slice("env:".length), context.platform) ?? "";
+    }
+
+    if (variable.startsWith("workspaceFolder:")) {
+      const name = variable.slice("workspaceFolder:".length);
+      return context.workspaceDirs.find((dir) => pathBasename(dir) === name) ?? match;
+    }
+
+    return match;
+  });
+}
+
+function readEnv(
+  env: Record<string, string | undefined>,
+  name: string,
+  platform: string,
+): string | undefined {
+  if (platform !== "win32") return env[name];
+  const key = Object.keys(env).find((candidate) => candidate.toLowerCase() === name.toLowerCase());
+  return key ? env[key] : undefined;
+}
+
+function pathBasename(filePath: string): string {
+  return (
+    filePath
+      .replace(/[\\/]+$/, "")
+      .split(/[\\/]/)
+      .pop() ?? ""
+  );
 }
 
 function windowsGlobalDirs(opts: ResolveOptions): string[] {

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -4,6 +4,7 @@ import * as vscode from "vscode";
 import { toErrorMessage } from "./bridge/utils.ts";
 import { createPiEnvironment, createPiRpcArgs, ensurePiBinary } from "./pi.ts";
 import { createNewTerminal } from "./terminal.ts";
+import { getActiveWorkspaceFolderPath } from "./workspace.ts";
 
 export function createChatHandler(options: {
   extensionUri: vscode.Uri;
@@ -56,7 +57,7 @@ async function runPiRpcPrompt(options: {
   extensionUri: vscode.Uri;
   bridgeConfig?: { url: string; token: string };
 }): Promise<{ hadOutput: boolean }> {
-  const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  const cwd = getActiveWorkspaceFolderPath(vscode);
   const child = spawn(options.piPath, createPiRpcArgs(options.extensionUri), {
     cwd,
     env: {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { createPiEnvironment, createPiShellArgs, findPiBinary, upgradePiBinary }
 import { createPackagesViewProvider } from "./packages.ts";
 import { createSessionTracker } from "./sessions.ts";
 import { buildOpenWithFileContext, createNewTerminal } from "./terminal.ts";
+import { getActiveWorkspaceFolderPath } from "./workspace.ts";
 
 let extensionUri: vscode.Uri;
 let bridgeConfig: { url: string; token: string } | undefined;
@@ -104,7 +105,7 @@ export async function activate(context: vscode.ExtensionContext) {
           name: TERMINAL_TITLE,
           shellPath: findPiBinary(),
           shellArgs: createPiShellArgs(extensionUri),
-          cwd: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
+          cwd: getActiveWorkspaceFolderPath(vscode),
           env: { ...baseEnv, PI_VSCODE_TERMINAL_ID: terminalId },
           iconPath: logoIcon,
         });

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { TERMINAL_TITLE } from "./constants.ts";
 import { createPiEnvironment, createPiShellArgs, ensurePiBinary } from "./pi.ts";
+import { getActiveWorkspaceFolderPath } from "./workspace.ts";
 
 export async function createNewTerminal(options: {
   extensionUri: vscode.Uri;
@@ -13,7 +14,7 @@ export async function createNewTerminal(options: {
   const piPath = await ensurePiBinary();
   if (!piPath) return undefined;
 
-  const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  const cwd = getActiveWorkspaceFolderPath(vscode);
   const viewColumn = findPiColumn() ?? findUnusedColumn() ?? vscode.ViewColumn.Beside;
   const extraArgs = options.sessionFile
     ? ["--session", options.sessionFile, ...(options.extraArgs ?? [])]
@@ -48,8 +49,8 @@ export async function createNewTerminal(options: {
 
 export function buildOpenWithFileContext(): string[] {
   const lines: string[] = [];
-  const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-  if (workspaceRoot) lines.push(`The workspace root is: ${workspaceRoot}`);
+  const workspaceRoot = getActiveWorkspaceFolderPath(vscode);
+  if (workspaceRoot) lines.push(`The active workspace root is: ${workspaceRoot}`);
 
   const editor = vscode.window.activeTextEditor;
   if (!editor) return lines;

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,0 +1,28 @@
+type WorkspaceFolderLike = { uri: { fsPath: string } };
+
+type WorkspaceApi<TFolder extends WorkspaceFolderLike, TUri> = {
+  workspaceFolders?: readonly TFolder[];
+  getWorkspaceFolder(uri: TUri): TFolder | undefined;
+};
+
+type WindowApi<TUri> = {
+  activeTextEditor?: { document: { uri: TUri } };
+};
+
+export function pickWorkspaceFolderPath<TFolder extends WorkspaceFolderLike>(
+  workspaceFolders: readonly TFolder[] | undefined,
+  activeWorkspaceFolder: TFolder | undefined,
+): string | undefined {
+  return activeWorkspaceFolder?.uri.fsPath ?? workspaceFolders?.[0]?.uri.fsPath;
+}
+
+export function getActiveWorkspaceFolderPath<TFolder extends WorkspaceFolderLike, TUri>(vscodeApi: {
+  workspace: WorkspaceApi<TFolder, TUri>;
+  window: WindowApi<TUri>;
+}): string | undefined {
+  const activeUri = vscodeApi.window.activeTextEditor?.document.uri;
+  return pickWorkspaceFolderPath(
+    vscodeApi.workspace.workspaceFolders,
+    activeUri ? vscodeApi.workspace.getWorkspaceFolder(activeUri) : undefined,
+  );
+}

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -2,6 +2,7 @@ import { constants } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolvePiBinary } from "../src/_resolve.ts";
+import { getActiveWorkspaceFolderPath, pickWorkspaceFolderPath } from "../src/workspace.ts";
 import {
   createPiGlobalInstallCommand,
   createPiUpgradeCommand,
@@ -243,6 +244,36 @@ describe("guessPiPackageManager", () => {
 
   it("returns undefined for ambiguous paths", () => {
     expect(guessPiPackageManager("/usr/local/bin/pi")).toBeUndefined();
+  });
+});
+
+describe("active workspace folder", () => {
+  const first = { uri: { fsPath: "/repo/api" } };
+  const second = { uri: { fsPath: "/repo/web" } };
+
+  it("uses the active editor workspace instead of the first folder", () => {
+    expect(pickWorkspaceFolderPath([first, second], second)).toBe("/repo/web");
+  });
+
+  it("falls back to the first folder when there is no active workspace", () => {
+    expect(pickWorkspaceFolderPath([first, second], undefined)).toBe("/repo/api");
+  });
+
+  it("resolves the active editor through the VS Code workspace API", () => {
+    const activeUri = { fsPath: "/repo/web/src/app.ts" };
+    const cwd = getActiveWorkspaceFolderPath({
+      workspace: {
+        workspaceFolders: [first, second],
+        getWorkspaceFolder(uri) {
+          return uri === activeUri ? second : undefined;
+        },
+      },
+      window: {
+        activeTextEditor: { document: { uri: activeUri } },
+      },
+    });
+
+    expect(cwd).toBe("/repo/web");
   });
 });
 

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -20,6 +20,62 @@ describe("resolvePiBinary", () => {
     expect(resolvePiBinary({ customPath: "/custom/pi" })).toBe("/custom/pi");
   });
 
+  it("expands VS Code userHome variable in custom path", () => {
+    expect(
+      resolvePiBinary({
+        customPath: "${userHome}/.bun/bin/aaa.exe",
+        home: "/Users/dev",
+        platform: "linux",
+      }),
+    ).toBe("/Users/dev/.bun/bin/aaa.exe");
+  });
+
+  it("expands VS Code path separator variable in custom path", () => {
+    expect(
+      resolvePiBinary({
+        customPath: "${userHome}${/}.bun${/}bin${/}aaa.exe",
+        home: "C:\\Users\\dev",
+        platform: "win32",
+      }),
+    ).toBe("C:\\Users\\dev\\.bun\\bin\\aaa.exe");
+  });
+
+  it("expands environment variables in custom path", () => {
+    expect(
+      resolvePiBinary({
+        customPath: "${env:BUN_INSTALL}/bin/pi",
+        env: { BUN_INSTALL: "/opt/bun" },
+        platform: "linux",
+      }),
+    ).toBe("/opt/bun/bin/pi");
+  });
+
+  it("expands Windows environment variables case-insensitively in custom path", () => {
+    expect(
+      resolvePiBinary({
+        customPath: "${env:localappdata}\\Programs\\pi\\pi.exe",
+        env: { LOCALAPPDATA: "C:\\Users\\dev\\AppData\\Local" },
+        platform: "win32",
+      }),
+    ).toBe("C:\\Users\\dev\\AppData\\Local\\Programs\\pi\\pi.exe");
+  });
+
+  it("keeps unknown variables unchanged in custom path", () => {
+    expect(resolvePiBinary({ customPath: "${unknown}/pi", platform: "linux" })).toBe(
+      "${unknown}/pi",
+    );
+  });
+
+  it("expands named workspace folders in custom path", () => {
+    expect(
+      resolvePiBinary({
+        customPath: "${workspaceFolder:Client}/node_modules/.bin/pi",
+        workspaceDirs: ["/repo/Server", "/repo/Client"],
+        platform: "linux",
+      }),
+    ).toBe("/repo/Client/node_modules/.bin/pi");
+  });
+
   it("resolves custom path to .cmd on windows when extensionless", () => {
     const customPath = "C:\\nvm4w\\nodejs\\pi";
     const cmdPath = "C:\\nvm4w\\nodejs\\pi.cmd";


### PR DESCRIPTION
## Summary
- Resolve Pi terminal cwd from the workspace folder containing the active editor in multi-root windows
- Apply the same active-workspace cwd selection to the terminal profile, Open with File context, and @pi chat RPC
- Support VS Code-style variables in pi-vscode.path, including `${userHome}`, `${workspaceFolder}`, `${workspaceFolder:name}`, `${env:NAME}`, and `${/}`
- Add unit coverage for active workspace selection, fallback behavior, and configured path variable expansion

## Verification
- pnpm run fmt
- pnpm run typecheck
- pnpm exec vitest run test/resolve.test.ts