### PR TITLE
feat: SCM 'Open with Pi' + active-editor-aware cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Each pi terminal launched by the extension loads a bundled pi extension that can
 | `vscode_format_range`         | Runs the active range formatter for a selection/range and applies the resulting edits            |
 | `vscode_clear_notifications`  | Clears the buffered bridge notification queue                                                    |
 | `vscode_show_notification`    | Shows an info, warning, or error notification inside VS Code                                     |
-| `vscode_open_worktree`        | Opens a git worktree folder in VS Code (new window by default)                                   |
+| `vscode_open_folder`          | Opens a folder in VS Code (new window by default)                                                |
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Minimal VS Code extension for [pi coding agent](https://pi.dev/).
 - **Editor awareness** — pi can inspect the active editor, current/latest selection, open editors, workspace folders, and VS Code diagnostics (LSP / lint / type errors)
 - **Live VS Code footer status** — pi's terminal UI shows the active VS Code file, cursor/selection, language, dirty marker, and diagnostic counts in its bottom status area
 - **Status bar button** — PI button in the status bar for quick access
+- **Open in Source Control** — Inline button and right-click context menu in the SCM view to open Pi in a repository/worktree directory
+- **Active-editor-aware cwd** — Pi terminal's working directory follows the active editor's workspace folder
 - **Open with file context** — Send current file path and line range (or cursor position) to pi, available from the editor title bar
 - **Send selection** — Send selected text directly to the pi terminal
 - **`@pi` chat participant** — Use `@pi` in VS Code Chat for streamed RPC-backed replies while keeping the terminal workflow for normal Pi sessions
@@ -42,6 +44,7 @@ ovsx get pi0.pi-vscode
 | ----------------------------- | ---------------- | ---------------------------------------------------------------------------------------- |
 | `Pi: Open`                    | `Ctrl+Alt+3`     | Open or focus the pi terminal                                                            |
 | `Pi: Open with File`          | Editor title bar | Open pi with current file context                                                        |
+| `Open with Pi`                | SCM toolbar/ctx  | Open pi terminal in the selected repository/worktree directory                           |
 | `Pi: Send Selection`          | —                | Send selected text to pi terminal                                                        |
 | `Pi: Upgrade Pi and Packages` | —                | Find the pi binary, infer its package manager, upgrade pi globally, then run `pi update` |
 
@@ -89,6 +92,7 @@ Each pi terminal launched by the extension loads a bundled pi extension that can
 | `vscode_format_range`         | Runs the active range formatter for a selection/range and applies the resulting edits            |
 | `vscode_clear_notifications`  | Clears the buffered bridge notification queue                                                    |
 | `vscode_show_notification`    | Shows an info, warning, or error notification inside VS Code                                     |
+| `vscode_open_worktree`        | Opens a git worktree folder in VS Code (new window by default)                                   |
 
 ### Notes
 

--- a/bridge/pi-vscode-bridge.js
+++ b/bridge/pi-vscode-bridge.js
@@ -788,15 +788,15 @@ export default function (pi) {
       rpcMethod: "showNotification",
     }),
     tool({
-      name: "vscode_open_worktree",
-      label: "VS Code Open Worktree",
-      description: "Open a git worktree folder in VS Code. Opens in a new window by default.",
+      name: "vscode_open_folder",
+      label: "VS Code Open Folder",
+      description: "Open a folder in VS Code. Opens in a new window by default.",
       parameters: {
         type: "object",
         properties: {
           folderPath: {
             type: "string",
-            description: "Absolute path to the worktree folder",
+            description: "Absolute path to the folder",
           },
           newWindow: {
             type: "boolean",

--- a/bridge/pi-vscode-bridge.js
+++ b/bridge/pi-vscode-bridge.js
@@ -787,6 +787,27 @@ export default function (pi) {
       },
       rpcMethod: "showNotification",
     }),
+    tool({
+      name: "vscode_open_worktree",
+      label: "VS Code Open Worktree",
+      description: "Open a git worktree folder in VS Code. Opens in a new window by default.",
+      parameters: {
+        type: "object",
+        properties: {
+          folderPath: {
+            type: "string",
+            description: "Absolute path to the worktree folder",
+          },
+          newWindow: {
+            type: "boolean",
+            description: "Open in a new window (default: true)",
+          },
+        },
+        required: ["folderPath"],
+        additionalProperties: false,
+      },
+      rpcMethod: "openFolder",
+    }),
   ];
 
   for (const toolDefinition of tools) pi.registerTool(toolDefinition);

--- a/package.json
+++ b/package.json
@@ -116,7 +116,11 @@
           "command": "pi-vscode.openInFolder",
           "title": "Open with Pi",
           "group": "3_worktree@2",
-          "arguments": [{ "rootUri": "${sourceControl.rootUri}" }]
+          "arguments": [
+            {
+              "rootUri": "${sourceControl.rootUri}"
+            }
+          ]
         }
       ],
       "scm/resourceState/context": [

--- a/package.json
+++ b/package.json
@@ -74,6 +74,14 @@
         }
       },
       {
+        "command": "pi-vscode.openInFolder",
+        "title": "Open with Pi",
+        "icon": {
+          "light": "assets/logo-light.svg",
+          "dark": "assets/logo.svg"
+        }
+      },
+      {
         "command": "pi-vscode.sendSelection",
         "title": "Pi: Send Selection"
       },
@@ -101,6 +109,21 @@
         {
           "command": "pi-vscode.openWithFile",
           "group": "navigation"
+        }
+      ],
+      "scm/sourceControl": [
+        {
+          "command": "pi-vscode.openInFolder",
+          "title": "Open with Pi",
+          "group": "3_worktree@2",
+          "arguments": [{ "rootUri": "${sourceControl.rootUri}" }]
+        }
+      ],
+      "scm/resourceState/context": [
+        {
+          "command": "pi-vscode.openInFolder",
+          "title": "Open with Pi",
+          "group": "navigation@99"
         }
       ]
     },

--- a/src/bridge/handlers.ts
+++ b/src/bridge/handlers.ts
@@ -95,6 +95,8 @@ export async function handleRpc(
       return showNotification(params);
     case "reportTerminalSession":
       return reportTerminalSession(params, state);
+    case "openFolder":
+      return openFolderHandler(params);
     default:
       throw new Error(`Unknown bridge method: ${method}`);
   }
@@ -105,6 +107,16 @@ function reportTerminalSession(params: Record<string, unknown>, state: BridgeSta
   const sessionFile = readRequiredString(params.sessionFile, "sessionFile");
   state.reportTerminalSession(terminalId, sessionFile);
   return { received: true };
+}
+
+async function openFolderHandler(params: Record<string, unknown>) {
+  const folderPath = readRequiredString(params.folderPath, "folderPath");
+  const newWindow = (params.newWindow as boolean) ?? true;
+  const uri = getFileUri(folderPath);
+  await vscode.commands.executeCommand("vscode.openFolder", uri, {
+    forceNewWindow: newWindow,
+  });
+  return { opened: true, folderPath: uri.fsPath };
 }
 
 function getStatus(state: BridgeState) {

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -56,7 +56,12 @@ async function runPiRpcPrompt(options: {
   extensionUri: vscode.Uri;
   bridgeConfig?: { url: string; token: string };
 }): Promise<{ hadOutput: boolean }> {
-  const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  const activeDocUri = vscode.window.activeTextEditor?.document?.uri;
+  const cwd =
+    (activeDocUri
+      ? vscode.workspace.getWorkspaceFolder(activeDocUri)?.uri.fsPath
+      : undefined) ??
+    vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
   const child = spawn(options.piPath, createPiRpcArgs(options.extensionUri), {
     cwd,
     env: {

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -57,11 +57,10 @@ async function runPiRpcPrompt(options: {
   bridgeConfig?: { url: string; token: string };
 }): Promise<{ hadOutput: boolean }> {
   const activeDocUri = vscode.window.activeTextEditor?.document?.uri;
-  const cwd =
-    (activeDocUri
-      ? vscode.workspace.getWorkspaceFolder(activeDocUri)?.uri.fsPath
-      : undefined) ??
-    vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  const activeFolder = activeDocUri
+    ? vscode.workspace.getWorkspaceFolder(activeDocUri)?.uri.fsPath
+    : undefined;
+  const cwd = activeFolder ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
   const child = spawn(options.piPath, createPiRpcArgs(options.extensionUri), {
     cwd,
     env: {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { dirname } from "node:path";
 import * as vscode from "vscode";
 import { createBridge } from "./bridge/server.ts";
 import { createChatHandler } from "./chat.ts";
@@ -72,6 +74,43 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("pi-vscode.open", async () => {
       const terminal = await openTerminal();
       terminal?.show();
+    }),
+    vscode.commands.registerCommand("pi-vscode.openInFolder", async (arg: unknown) => {
+      try {
+        const src: Record<string, unknown> | undefined = Array.isArray(arg)
+          ? (arg[0] as Record<string, unknown> | undefined)
+          : (arg as Record<string, unknown> | undefined);
+        const uriVal: unknown = src?.rootUri ?? src?.resourceUri ?? src?.uri;
+        if (!uriVal) return;
+        const rootUri =
+          typeof uriVal === "string" ? vscode.Uri.parse(uriVal) : (uriVal as vscode.Uri);
+        let cwd: string | undefined = rootUri.fsPath || rootUri.path;
+        if (!cwd) return;
+        // Resolve to git root
+        try {
+          const top = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+            cwd: dirname(cwd),
+            encoding: "utf-8",
+          }).trim();
+          if (top) cwd = top;
+        } catch {
+          // not a git repo, use the path as-is
+        }
+        const terminalId = randomUUID();
+        const terminal = await createNewTerminal({
+          extensionUri,
+          bridgeConfig,
+          extraArgs: [],
+          cwd,
+          terminalId,
+        });
+        if (terminal) {
+          sessions.track(terminal, terminalId);
+          terminal.show();
+        }
+      } catch {
+        // silently ignore errors
+      }
     }),
     vscode.commands.registerCommand("pi-vscode.openWithFile", async () => {
       const terminal = await openTerminal(undefined, buildOpenWithFileContext());

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,7 +86,9 @@ export async function activate(context: vscode.ExtensionContext) {
           typeof uriVal === "string" ? vscode.Uri.parse(uriVal) : (uriVal as vscode.Uri);
         let cwd: string | undefined = rootUri.fsPath || rootUri.path;
         if (!cwd) return;
-        // Resolve to git root
+        // Resolve to git root. git walks up from any directory, so
+        // dirname handles both file paths (scm/resourceState/context)
+        // and directory paths without needing a separate stat.
         try {
           const top = execFileSync("git", ["rev-parse", "--show-toplevel"], {
             cwd: dirname(cwd),
@@ -108,8 +110,8 @@ export async function activate(context: vscode.ExtensionContext) {
           sessions.track(terminal, terminalId);
           terminal.show();
         }
-      } catch {
-        // silently ignore errors
+      } catch (err) {
+        console.warn("pi-vscode: openInFolder failed:", err);
       }
     }),
     vscode.commands.registerCommand("pi-vscode.openWithFile", async () => {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -9,11 +9,18 @@ export async function createNewTerminal(options: {
   contextLines?: string[];
   terminalId?: string;
   sessionFile?: string;
+  cwd?: string;
 }): Promise<vscode.Terminal | undefined> {
   const piPath = await ensurePiBinary();
   if (!piPath) return undefined;
 
-  const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  const activeDocUri = vscode.window.activeTextEditor?.document?.uri;
+  const cwd =
+    options.cwd ??
+    (activeDocUri
+      ? vscode.workspace.getWorkspaceFolder(activeDocUri)?.uri.fsPath
+      : undefined) ??
+    vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
   const viewColumn = findPiColumn() ?? findUnusedColumn() ?? vscode.ViewColumn.Beside;
   const extraArgs = options.sessionFile
     ? ["--session", options.sessionFile, ...(options.extraArgs ?? [])]

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -15,12 +15,10 @@ export async function createNewTerminal(options: {
   if (!piPath) return undefined;
 
   const activeDocUri = vscode.window.activeTextEditor?.document?.uri;
-  const cwd =
-    options.cwd ??
-    (activeDocUri
-      ? vscode.workspace.getWorkspaceFolder(activeDocUri)?.uri.fsPath
-      : undefined) ??
-    vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  const activeFolder = activeDocUri
+    ? vscode.workspace.getWorkspaceFolder(activeDocUri)?.uri.fsPath
+    : undefined;
+  const cwd = options.cwd ?? activeFolder ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
   const viewColumn = findPiColumn() ?? findUnusedColumn() ?? vscode.ViewColumn.Beside;
   const extraArgs = options.sessionFile
     ? ["--session", options.sessionFile, ...(options.extraArgs ?? [])]


### PR DESCRIPTION
## Summary

- Add `Open with Pi` inline button and context menu in the SCM view that opens a pi terminal in the selected repository/worktree directory, resolving to the git root automatically
- Make pi terminal cwd follow the active editor's workspace folder (active-editor-aware), falling back to the first workspace folder
- Add `vscode_open_folder` bridge tool to open any folder in VS Code from pi
- Refactor cwd resolution to flatten nested ternaries for readability
- Improve error logging for the openInFolder command

## Type of change

- [x] `feat` — new feature or command
- [x] `refactor` — code restructure, no behavior change

## Verification

- [x] Lint and format pass (`pnpm fmt`)
- [x] Typecheck passes (`pnpm typecheck`)
