### PR TITLE
fix: use exec/spawn with shell for Windows .cmd compatibility

### DIFF
--- a/src/packages.ts
+++ b/src/packages.ts
@@ -1,4 +1,4 @@
-import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { exec, spawn, type ChildProcess } from "node:child_process";
 import * as vscode from "vscode";
 
 export function createPackagesViewProvider(findPiBinary: () => string): vscode.WebviewViewProvider {
@@ -10,7 +10,7 @@ export function createPackagesViewProvider(findPiBinary: () => string): vscode.W
 
       const refreshInstalled = () => {
         const bin = findPiBinary();
-        execFile(bin, ["list"], (_err, stdout) => {
+        exec(bin.split('\\').join('/') + ' list', { windowsHide: true }, (_err, stdout) => {
           const packages = parseInstalledPackages(stdout || "");
           webviewView.webview.postMessage({ type: "installed", packages });
         });
@@ -19,7 +19,7 @@ export function createPackagesViewProvider(findPiBinary: () => string): vscode.W
       const runCommand = (args: string[]) => {
         const bin = findPiBinary();
         webviewView.webview.postMessage({ type: "loading", loading: true, output: "" });
-        const proc = spawn(bin, args);
+        const proc = spawn(bin, args, { shell: true });
         activeProcess = proc;
         const onData = (chunk: Buffer) => {
           webviewView.webview.postMessage({ type: "output", text: chunk.toString() });


### PR DESCRIPTION
## Problem

Clicking the Pi icon in the activity bar to open the Packages sidebar shows:

> An error occurred while loading view: pi-vscode.packages

On Windows, `findPiBinary()` resolves to a `.cmd` file (e.g. `node_modules/.bin/pi.cmd`). `execFile` and `spawn` without `{ shell: true }` cannot execute `.cmd` batch scripts directly, producing `spawn EINVAL`.

## Fix

- `execFile` → `exec` with forward-slash path conversion (`bin.split('\\').join('/')`)
- `spawn` → `spawn` with `{ shell: true }`

This is a known Windows + Node.js ≥ 20.14 issue (Electron 30 breaking change for `.bat`/`.cmd` execution).

Fixes #19

## Verification

- [x] `pnpm fmt` passes
- [x] `pnpm typecheck` passes
- [x] Tested on Windows 10 Pro (Build 19045) with Node.js v24.14.1 — Packages view loads and lists installed packages